### PR TITLE
Fix/take market from config correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/InjectiveLabs/metrics v0.0.1
-	github.com/InjectiveLabs/sdk-go v1.50.0
+	github.com/InjectiveLabs/sdk-go v1.50.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cosmos/cosmos-sdk v0.47.5
 	github.com/ethereum/go-ethereum v1.11.5

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/InjectiveLabs/ibc-go/v7 v7.2.0-inj h1:CtzShjiD+mGQktWYS0kTzUu8hQaDOmt
 github.com/InjectiveLabs/ibc-go/v7 v7.2.0-inj/go.mod h1:aEQF2stK9Bi/J56kW93MHlcKIF1uSt204mTngJYdNcY=
 github.com/InjectiveLabs/metrics v0.0.1 h1:MXNj8JWOdIqiGZw83JdUTR+i6hgBrb12HatIUvaly9I=
 github.com/InjectiveLabs/metrics v0.0.1/go.mod h1:Dmgd60Z0pfi7uOGSUzyqZ00tbMYmZK25u8Sjgk3Ay4A=
-github.com/InjectiveLabs/sdk-go v1.50.0 h1:dKHUZ1AC7BLxP5srUFsdRjGaP3cyo//Okr8KRW06tDk=
-github.com/InjectiveLabs/sdk-go v1.50.0/go.mod h1:ecmY701q1cAZaNdeuzs08x7diCC8z5qjvcpbETR81oY=
+github.com/InjectiveLabs/sdk-go v1.50.1 h1:S4Pg+SJF6MI18A2OFg+GmTJwpJmgQs7H5Mqxi8klCAI=
+github.com/InjectiveLabs/sdk-go v1.50.1/go.mod h1:u2sA/g0Sz/z+/qsJHSPue+i5OY5KsZY7izfKdZ5HB8c=
 github.com/InjectiveLabs/suplog v1.3.3 h1:ARIR3lWD9BxcrmqTwgcGBt8t7e10gwOqllUAXa/MfxI=
 github.com/InjectiveLabs/suplog v1.3.3/go.mod h1:+I9WRgUhzmo1V/n7IkW24kFBFB9ZTPAiXXXCogWxmTM=
 github.com/InjectiveLabs/wasmd v0.45.0-inj h1:hYRzxEiBNJqJA7EoE9kMTFpWayjT2ICo/FsmtAf8A+o=

--- a/liquidator/service.go
+++ b/liquidator/service.go
@@ -2,7 +2,6 @@ package liquidator
 
 import (
 	"context"
-	sdkCommon "github.com/InjectiveLabs/sdk-go/client/common"
 	"github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -97,14 +96,13 @@ func (s *liquidatorSvc) Start() (err error) {
 
 				order := s.chainClient.CreateDerivativeOrder(
 					s.subaccountID,
-					sdkCommon.NewNetwork(),
 					&chainclient.DerivativeOrderData{
 						OrderType:    orderType,
 						Quantity:     market.QuantityFromChainFormat(types.MustNewDecFromStr(position.Quantity)),
 						Price:        market.PriceFromChainFormat(types.MustNewDecFromStr(position.MarkPrice)),
 						Leverage:     decimal.RequireFromString("1"),
 						FeeRecipient: s.chainClient.FromAddress().String(),
-						MarketId:     "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
+						MarketId:     market.Id,
 						Cid:          uuid.NewString(),
 					},
 					s.marketsAssistant,

--- a/restart.sh
+++ b/restart.sh
@@ -1,1 +1,1 @@
-go run cmd/injective-liquidator-bot/main.go cmd/injective-liquidator-bot/util.go cmd/injective-liquidator-bot/options.go cmd/injective-liquidator-bot/metrics.go cmd/injective-liquidator-bot/liquidator.go cmd/injective-liquidator-bot/keys.go start
+go run cmd/injective-liquidator-bot/main.go cmd/injective-liquidator-bot/util.go cmd/injective-liquidator-bot/options.go cmd/injective-liquidator-bot/metrics.go cmd/injective-liquidator-bot/liquidator.go start

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	AppVersion = "0.1"
+	AppVersion = "0.2"
 	GitCommit  = ""
 	BuildDate  = ""
 


### PR DESCRIPTION
- Fixed an issue when creating the liquidation order. The market for the order was not taken from the configuration.
- Updated the Go SDK version used change the Derivative Order creation logic to adapt to the new API
- Fixed an error in the `restart.sh` script